### PR TITLE
Fix fs import order

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 import YAML from "yaml";
+import fs from "node:fs";
+import path from "node:path";
 const apps = {};
 global.xiaotan_plugin = {
   apps: apps,
@@ -48,8 +50,6 @@ if (!xiaotan_plugin.puppeteer) {
   }
 }
 
-import fs from "node:fs";
-import path from "node:path";
 import { Version, Plugin_Path } from "./components/index.js";
 
 function getAllJsFiles(dirPath, arrayOfFiles = []) {


### PR DESCRIPTION
## Summary
- load `fs` and `path` before using them in `index.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68456a0fc82483249f4b34555084c39a